### PR TITLE
 PREMIUMAPP-3173 :upstream latest netflix changes

### DIFF
--- a/rdk_gstreamer_utils.cpp
+++ b/rdk_gstreamer_utils.cpp
@@ -148,18 +148,18 @@ namespace rdk_gstreamer_utils {
         }
     }
 
-    void configAudioCap(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps)
+    void configAudioCap(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps, bool passthroughProperty)
     {
-        configAudioCap_soc(pAttrib,audioaac,svpenabled,appsrcCaps);
+        configAudioCap_soc(pAttrib,audioaac,svpenabled,appsrcCaps,passthroughProperty);
     }
 
     bool performAudioTrackCodecChannelSwitch(struct rdkGstreamerUtilsPlaybackGrp *pgstUtilsPlaybackGroup,const void *pSampleAttr, AudioAttributes *pAudioAttr, uint32_t *pStatus, unsigned int *pui32Delay,
                                                  llong *pAudioChangeTargetPts,const llong *pcurrentDispPts, unsigned int *audio_change_stage, GstCaps **appsrcCaps,
-                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret)
+                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret, bool passthroughProperty)
     {
         return performAudioTrackCodecChannelSwitch_soc(pgstUtilsPlaybackGroup, pSampleAttr,pAudioAttr,pStatus, pui32Delay,
                                                 pAudioChangeTargetPts,pcurrentDispPts,audio_change_stage,appsrcCaps,
-                                                audioaac,svpenabled, aSrc,ret);
+                                                audioaac,svpenabled, aSrc,ret,passthroughProperty);
     }
 
     void setAppSrcParams(GstElement *aSrc,MediaType mediatype)
@@ -231,4 +231,10 @@ namespace rdk_gstreamer_utils {
     {
        SetAudioServerParam_soc(enabled);
     }
+
+    void constructLLAudioPlayer(int numChannel ,GstElement *gstPipeline ,GstElement *aSrc,GstElement *aSink,GstElement *aFilter,GstElement *aDecoder)
+    {
+        constructLLAudioPlayer_soc(numChannel,gstPipeline ,aSrc,aSink,aFilter,aDecoder);
+    }
+
 } // namespace rdk_gstreamer_utils

--- a/rdk_gstreamer_utils.h
+++ b/rdk_gstreamer_utils.h
@@ -140,10 +140,12 @@ namespace rdk_gstreamer_utils {
     bool isUIAudioVGAudioMixSupported();
     std::map<rgu_gstelement,GstElement *> createNewAudioElements(bool isAudioAAC,bool createqueue);
     unsigned getNativeAudioFlag();
-    void configAudioCap(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps);
+    /* configAudioCap interface extended with passthroughProperty for NF7 */
+    void configAudioCap(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps, bool passthroughProperty=true);
+    /* performAudioTrackCodecChannelSwitch interface extended with passthroughProperty for NF7 */
     bool performAudioTrackCodecChannelSwitch(struct rdkGstreamerUtilsPlaybackGrp *pgstUtilsPlaybackGroup, const void *pSampleAttr, AudioAttributes *pAudioAttr, uint32_t *pStatus, unsigned int *pui32Delay,
                                                  llong *pAudioChangeTargetPts, const llong *pcurrentDispPts, unsigned int *audio_change_stage, GstCaps **appsrcCaps,
-                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret);
+                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret, bool passthroughProperty=true);
     void setAppSrcParams(GstElement *aSrc,MediaType mediatype);
     void setPixelAspectRatio(GstCaps ** ppCaps,GstCaps *appsrcCaps,uint32_t pixelAspectRatioX,uint32_t pixelAspectRatioY);
     void deepElementAdded(struct rdkGstreamerUtilsPlaybackGrp *pgstUtilsPlaybackGroup, GstBin* pipeline, GstBin* bin, GstElement* element);
@@ -158,5 +160,6 @@ namespace rdk_gstreamer_utils {
     void setKeyFrameFlag(GstBuffer *gstBuffer,bool val);
     bool getDelayTimerEnabled();
     void SetAudioServerParam(bool enabled);
+    void constructLLAudioPlayer(int numChannel ,GstElement *gstPipeline ,GstElement *aSrc,GstElement *aSink,GstElement *aFilter,GstElement *aDecoder);
 } // namespace rdk_gstreamer_utils
 #endif /* __RDK_GSTREAMER_UTILS_H___ */

--- a/rdk_gstreamer_utils_soc.h
+++ b/rdk_gstreamer_utils_soc.h
@@ -36,10 +36,10 @@ namespace rdk_gstreamer_utils
     GstElement * configureUIAudioSink_soc(bool TTSenabled);
     bool isUIAudioVGAudioMixSupported_soc();
     unsigned int getNativeAudioFlag_soc();
-    void configAudioCap_soc(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps);
+    void configAudioCap_soc(AudioAttributes *pAttrib, bool *audioaac, bool svpenabled, GstCaps **appsrcCaps, bool passthroughProperty);
     bool performAudioTrackCodecChannelSwitch_soc(struct rdkGstreamerUtilsPlaybackGrp *pgstUtilsPlaybackGroup, const void *pSampleAttr, AudioAttributes *pAudioAttr, uint32_t *pStatus, unsigned int *pui32Delay,
                                                  llong *pAudioChangeTargetPts, const llong *pcurrentDispPts, unsigned int *audio_change_stage, GstCaps **appsrcCaps,
-                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret);
+                                                 bool *audioaac, bool svpenabled, GstElement *aSrc, bool *ret, bool passthroughProperty);
     void setAppSrcParams_soc(GstElement *aSrc,MediaType mediatype);
     void setPixelAspectRatio_soc(GstCaps ** ppCaps,GstCaps *appsrcCaps,uint32_t pixelAspectRatioX,uint32_t pixelAspectRatioY);
     void deepElementAdded_soc (struct rdkGstreamerUtilsPlaybackGrp *pgstUtilsPlaybackGroup, GstBin* pipeline, GstBin* bin, GstElement* element);
@@ -54,4 +54,5 @@ namespace rdk_gstreamer_utils
     void setKeyFrameFlag_soc(GstBuffer *gstBuffer,bool val);
     bool getDelayTimerEnabled_soc();
     void SetAudioServerParam_soc(bool enabled);
+    void constructLLAudioPlayer_soc(int numChannel ,GstElement *gstPipeline ,GstElement *aSrc,GstElement *aSink,GstElement *aFilter,GstElement *aDecoder);
 } //namespace rdk_gstreamer_utils


### PR DESCRIPTION
Changes included:     
1.BCOM-6371, BCOM-6946 :Use synclib streaming if available    
2.RDK-53235 : Generify Netflix7 code
  
  **Note** : Respective changes to brcm and rialto folders not added since these would be moved to the vendor layer.