### PR TITLE
RDKEVD-2353: Move Playready DRM abstracted API to separate shared obje…

### DIFF
--- a/rdk_gstreamer_utils.cpp
+++ b/rdk_gstreamer_utils.cpp
@@ -269,17 +269,17 @@ namespace rdk_gstreamer_utils {
         }
     }
 
-    bool Drmhal_QueryBatchIDFromLicenseRespone(void *pstdrmLicenseResponse, void *pstDRMBatchID)
+    bool Drmhal_QueryBatchIDFromLicenseResponse(void *pstdrmLicenseResponse, void *pstDRMBatchID)
     {
-        typedef bool (*Drmhal_QueryBatchIDFromLicenseRespone_soc_Func)(void*, void*);
-        static Drmhal_QueryBatchIDFromLicenseRespone_soc_Func func = nullptr;
+        typedef bool (*Drmhal_QueryBatchIDFromLicenseResponse_soc_Func)(void*, void*);
+        static Drmhal_QueryBatchIDFromLicenseResponse_soc_Func func = nullptr;
         if (!func) {
-            func = (Drmhal_QueryBatchIDFromLicenseRespone_soc_Func)dlsym(RTLD_DEFAULT, "Drmhal_QueryBatchIDFromLicenseRespone_soc");
+            func = (Drmhal_QueryBatchIDFromLicenseResponse_soc_Func)dlsym(RTLD_DEFAULT, "Drmhal_QueryBatchIDFromLicenseResponse_soc");
         }
         if (func) {
             return func(pstdrmLicenseResponse, pstDRMBatchID);
         } else {
-            printf("Drmhal_QueryBatchIDFromLicenseRespone_soc symbol not found via dlsym\n");
+            printf("Drmhal_QueryBatchIDFromLicenseResponse_soc symbol not found via dlsym\n");
             return false;
         }
     }

--- a/rdk_gstreamer_utils_soc.h
+++ b/rdk_gstreamer_utils_soc.h
@@ -64,7 +64,7 @@ namespace rdk_gstreamer_utils
 
     uint32_t Drmhal_DeleteDrmStore_soc(void* mDrmStore, std::string DrmStorePath);
 
-    bool Drmhal_QueryBatchIDFromLicenseRespone_soc(void *pstdrmLicenseResponse, void *pstDRMBatchID);
+    bool Drmhal_QueryBatchIDFromLicenseResponse_soc(void *pstdrmLicenseResponse, void *pstDRMBatchID);
 
     bool Drmhal_bindCallbackPrecheck_soc(int f_dwCallbackType);
 


### PR DESCRIPTION
Reason for change: Changed function name typo
Risks: None
Priority: P1